### PR TITLE
[fix] Jwt 토큰 재발급을 위한 코드 수정 작업

### DIFF
--- a/src/main/java/store/teabliss/common/config/SecurityConfig.java
+++ b/src/main/java/store/teabliss/common/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import store.teabliss.common.security.oauth2.handler.OAuth2AuthenticationFailureHandler;
 import store.teabliss.common.security.oauth2.handler.OAuth2AuthenticationSuccessHandler;
+import store.teabliss.common.security.signin.JwtExceptionFilter;
 import store.teabliss.common.security.signin.UsernamePasswordAuthenticationFilter;
 import store.teabliss.common.security.signin.handler.SignInFailureHandler;
 import store.teabliss.common.security.signin.handler.SignInSuccessHandler;
@@ -102,7 +103,8 @@ public class SecurityConfig {
 
         http
                 .addFilterAfter(usernamePasswordAuthenticationFilter(), LogoutFilter.class)
-                .addFilterBefore(jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter(), JwtAuthorizationFilter.class);
 
 
         return http.build();
@@ -152,7 +154,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    UsernamePasswordAuthenticationFilter usernamePasswordAuthenticationFilter() throws Exception{
+    public UsernamePasswordAuthenticationFilter usernamePasswordAuthenticationFilter() throws Exception{
         UsernamePasswordAuthenticationFilter usernamePasswordAuthenticationFilter = new UsernamePasswordAuthenticationFilter(objectMapper);
         usernamePasswordAuthenticationFilter.setAuthenticationManager(authenticationManager());
         usernamePasswordAuthenticationFilter.setAuthenticationSuccessHandler(signInSuccessHandler());
@@ -161,8 +163,12 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtAuthorizationFilter jwtAuthenticationProcessingFilter(){
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
         return new JwtAuthorizationFilter(memberMapper, jwtService);
     }
 
+    @Bean
+    public JwtExceptionFilter jwtExceptionFilter() {
+        return new JwtExceptionFilter();
+    }
 }

--- a/src/main/java/store/teabliss/common/entity/ErrorMessage.java
+++ b/src/main/java/store/teabliss/common/entity/ErrorMessage.java
@@ -1,0 +1,23 @@
+package store.teabliss.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "인증 토큰이 존재하지 않습니다."),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰 정보입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 정보입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰 방식입니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "알 수 없는 이유로 요청이 거절되었습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String msg;
+
+    public int getCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/store/teabliss/common/security/signin/JwtAuthorizationFilter.java
+++ b/src/main/java/store/teabliss/common/security/signin/JwtAuthorizationFilter.java
@@ -31,20 +31,23 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (request.getRequestURI().equals(NO_CHECK_URL)) {
+        if (request.getRequestURI().equals(NO_CHECK_URL) ) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String refreshToken = jwtService
-                .extractRefreshToken(request)
-                .filter(jwtService::isTokenValid)
-                .orElse(null);
-
-        if (refreshToken != null) {
-            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
-            return;
-        }
+        /*
+            2024-06-21, Header 형식 RefreshToken 검증 주석 처리
+         */
+        // String refreshToken = jwtService
+        //         .extractRefreshToken(request)
+        //         .filter(jwtService::isTokenValid)
+        //         .orElse(null);
+        //
+        // if (refreshToken != null) {
+        //     checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+        //     return;
+        // }
 
         checkAccessTokenAndAuthentication(request, response, filterChain);
     }

--- a/src/main/java/store/teabliss/common/security/signin/JwtExceptionFilter.java
+++ b/src/main/java/store/teabliss/common/security/signin/JwtExceptionFilter.java
@@ -1,0 +1,53 @@
+package store.teabliss.common.security.signin;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import store.teabliss.common.entity.ErrorMessage;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        try {
+            chain.doFilter(request, response);
+        } catch (JwtException ex) {
+            String message = ex.getMessage();
+            if(ErrorMessage.UNKNOWN_ERROR.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.UNKNOWN_ERROR);
+            }
+            //잘못된 타입의 토큰인 경우
+            else if(ErrorMessage.WRONG_TYPE_TOKEN.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.WRONG_TYPE_TOKEN);
+            }
+            //토큰 만료된 경우
+            else if(ErrorMessage.EXPIRED_TOKEN.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.EXPIRED_TOKEN);
+            }
+            //지원되지 않는 토큰인 경우
+            else if(ErrorMessage.UNSUPPORTED_TOKEN.getMsg().equals(message)) {
+                setResponse(response, ErrorMessage.UNSUPPORTED_TOKEN);
+            }
+            else {
+                setResponse(response, ErrorMessage.ACCESS_DENIED);
+            }
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorMessage errorMessage) throws RuntimeException, IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorMessage.getCode());
+        response.getWriter().print(errorMessage.getMsg());
+    }
+}

--- a/src/main/java/store/teabliss/common/security/signin/handler/SignInSuccessHandler.java
+++ b/src/main/java/store/teabliss/common/security/signin/handler/SignInSuccessHandler.java
@@ -40,7 +40,7 @@ public class SignInSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         member.updateRefreshToken(refreshToken);
 
-        memberMapper.updateMember(member);
+        memberMapper.updateRefreshToken(member);
 
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 

--- a/src/main/java/store/teabliss/common/security/signin/response/JwtErrorResponse.java
+++ b/src/main/java/store/teabliss/common/security/signin/response/JwtErrorResponse.java
@@ -1,0 +1,19 @@
+package store.teabliss.common.security.signin.response;
+
+import lombok.Getter;
+import store.teabliss.common.response.CommonResponse;
+
+@Getter
+public class JwtErrorResponse extends CommonResponse {
+
+    private final String code;
+
+    public JwtErrorResponse(int status, String code, String message) {
+        super(status, message);
+        this.code = code;
+    }
+
+    public static JwtErrorResponse error(String code, String message) {
+        return new JwtErrorResponse(400, code, message);
+    }
+}

--- a/src/main/java/store/teabliss/common/security/signin/service/JwtService.java
+++ b/src/main/java/store/teabliss/common/security/signin/service/JwtService.java
@@ -11,16 +11,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.WebUtils;
+import store.teabliss.common.entity.ErrorMessage;
 import store.teabliss.common.security.utils.CookieUtils;
 import store.teabliss.member.entity.Member;
 import store.teabliss.member.mapper.MemberMapper;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +30,7 @@ public class JwtService {
     private String secret;
 
     private static final long ACCESS_TOKEN_EXPIRED_TIME = 1000L * 60L * 60L * 24L; // 1일
-    private static final long REFRESH_TOKEN_EXPIRED_TIME = 1000L * 60L * 60L * 24L * 7L; // 7일
+    private static final long REFRESH_TOKEN_EXPIRED_TIME = 1000L; // 7일
     private static final String ACCESS_TOKEN = "Authorization";
     private static final String REFRESH_TOKEN = "RefreshToken";
     private static final String BEARER = "Bearer ";
@@ -125,7 +124,13 @@ public class JwtService {
     }
 
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(REFRESH_TOKEN));
+        Cookie refreshToken = WebUtils.getCookie(request, "refreshToken");
+
+        if(refreshToken == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(refreshToken.getValue());
     }
 
     public Optional<String> extractEmail(String accessToken) {
@@ -149,18 +154,15 @@ public class JwtService {
                     .parseClaimsJws(token);
 
             return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            throw new RuntimeException("잘못된 JWT 서명입니다.");
-            // throw new JwtErrorException(JwtErrorStatus.MALFORMED_JWT);
+        } catch (MalformedJwtException e) {
+            log.info("MalformedJwtException");
+            throw new JwtException(ErrorMessage.UNSUPPORTED_TOKEN.getMsg());
         } catch (ExpiredJwtException e) {
-            throw new RuntimeException("만료된 JWT 토큰입니다.");
-            // throw new JwtErrorException(JwtErrorStatus.EXPIRED_JWT);
-        } catch (UnsupportedJwtException e) {
-            throw new RuntimeException("지원되지 않는 JWT 토큰입니다.");
-            // throw new JwtErrorException(JwtErrorStatus.UNSUPPORTED_JWT);
+            log.info("ExpiredJwtException");
+            throw new JwtException(ErrorMessage.EXPIRED_TOKEN.getMsg());
         } catch (IllegalArgumentException e) {
-            throw new RuntimeException("JWT 토큰이 잘못되었습니다.");
-            // throw new JwtErrorException(JwtErrorStatus.ILLEGAL_ARGUMENT);
+            log.info("IllegalArgumentException");
+            throw new JwtException(ErrorMessage.UNKNOWN_ERROR.getMsg());
         }
     }
 }

--- a/src/main/java/store/teabliss/member/controller/MemberController.java
+++ b/src/main/java/store/teabliss/member/controller/MemberController.java
@@ -2,11 +2,14 @@ package store.teabliss.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import store.teabliss.common.security.signin.service.JwtService;
 import store.teabliss.member.dto.*;
 import store.teabliss.member.entity.MemberDetails;
 import store.teabliss.member.service.MemberService;
@@ -84,5 +87,23 @@ public class MemberController {
         int result = memberService.updateAddress(memberDetails.getMemberId(), memberAddressDto);
 
         return ResponseEntity.ok(MemberResponse.ok(result));
+    }
+
+    @GetMapping("/re-issue")
+    @Operation(summary = "엑세스 토큰 만료 시 Refresh Token 검증", description = "엑세스 토큰 만료 시 Refresh Token 검증 API")
+    public ResponseEntity<MemberResponse> reIssue(
+            HttpServletResponse response,
+            @CookieValue(name = "refreshToken") String refreshToken
+    ) {
+
+        if(refreshToken.isEmpty()) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(MemberResponse.error("다시 로그인을 하시기 바랍니다."));
+        }
+
+        memberService.reIssue(response, refreshToken);
+
+        return ResponseEntity.ok(MemberResponse.ok("Access Token 재발급 처리"));
     }
 }

--- a/src/main/java/store/teabliss/member/dto/MemberResponse.java
+++ b/src/main/java/store/teabliss/member/dto/MemberResponse.java
@@ -30,6 +30,10 @@ public class MemberResponse extends CommonResponse {
         return new MemberResponse(200, "Success", member, total);
     }
 
+    public static MemberResponse error(String message) {
+        return new MemberResponse(400, message, null, null);
+    }
+
     public static MemberResponse profileError() {
         return new MemberResponse(400, "해당 프로필 파일은 10MB를 넘기면 안됩니다.", null, null);
     }

--- a/src/main/java/store/teabliss/member/exception/MemberExceptionHandler.java
+++ b/src/main/java/store/teabliss/member/exception/MemberExceptionHandler.java
@@ -1,5 +1,6 @@
 package store.teabliss.member.exception;
 
+import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -81,5 +82,15 @@ public class MemberExceptionHandler {
                 .build();
 
         return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(JwtException.class)
+    private ResponseEntity<MemberResponse> jwtRefreshTokenNotValidException(JwtException e) {
+        MemberResponse response = MemberResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .message("Refresh Token 만료로 인한 재로그인을 시도해주세요.")
+                .build();
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
     }
 }

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -65,7 +65,7 @@
         *
         FROM MEMBER
         WHERE 1=1
-        AND refreshToken = #{value}
+        AND refresh_token = #{value}
     </select>
 
     <select id="findByMembers" parameterType="Member">


### PR DESCRIPTION
### PR 타입
- [v] 기능 추가
- [v] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/admin -> dev

### 변경 사항
- Header 형식의 Refresh Token 재발급 제거.
- Cookie로 받는 Refresh Token을 위한 MemberController에 '/re-issue' API 추가.
- Access Token 만료 / Refresh Token 조회를 통한 재발급 / Refresh Token 만료 시 메시지 출력 등 코드 작업.

### 테스트 결과
- Access Token 만료: Refresh Token을 조회 후 재발급 처리
- Refresh Token 만료: 재로그인 시도하라는 에러 메시지 출력.